### PR TITLE
"copyfiles" block allows documents to request files to copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # ChangeLog
 
+## v1.0.3
+
+### Features
+
+- A new `copyfiles` code fence allows a Markdown file to declare files to be copied without linking to them directly. This is useful when linking to an HTML file that itself links to additional files that must be copied.
+
 ## v1.0.2
 
 ### Fixes

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Copies local files relative linked to/from markdown to your `public` folder with preserve directory structure.
 
-This will copy the files linked relative to all Markdowns like [gatsby-remark-copy-linked-files](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files) into a public directory structure like [gatsby-remark-copy-images](https://github.com/mojodna/gatsby-remark-copy-images) as it is.
+This will copy the files linked relative to all Markdowns like [gatsby-remark-copy-linked-files](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-copy-linked-files) into a public directory structure like [gatsby-remark-copy-images](https://github.com/mojodna/gatsby-remark-copy-images) as it is. It can also copy additional files requested by the document.
 
 ## Install
 
@@ -29,27 +29,37 @@ plugins: [
 ]
 ```
 
+*Note:* When using the `copyfiles` code fence (see below), `gatsby-remark-copy-relative-linked-files` must appear before general purpose code fence processors like `gatsby-remark-prismjs`.
+
 Then in your Markdown files, simply reference the files.
 
 ### E.g.
 
 ```markdown
----
-title: My awesome blog post
----
+    ---
+    title: My awesome blog post
+    ---
 
-Hey everyone, I just made a sweet files with lots of interesting stuff in
-it.
+    Hey everyone, I just made a sweet files with lots of interesting stuff in
+    it.
 
-- ![](image.gif)
-- [archive.zip](archive.zip)
-- [sample.pdf](sample.pdf)
-- [not-copy.rar](https://example.com/not-copy.rar)
+    - ![](image.gif)
+    - [archive.zip](archive.zip)
+    - [sample.pdf](sample.pdf)
+    - [report.html](report.html)
+    - [not-copy.rar](https://example.com/not-copy.rar)
+
+    ```copyfiles
+    report.css
+    diagram.png
+    ```
 ```
 
-`image.gif`, `archive.zip` and `sample.pdf` should be in the same directory as the markdown file. When you build your site, the file will be copied to the public folder and the markdown HTML will be modified to point to it.
+`image.gif`, `archive.zip`, `sample.pdf` and `report.html` should be in the same directory as the Markdown file. When you build your site, the file will be copied to the public folder and the markdown HTML will be modified to point to it.
 
-The copy target is a relative link. Therefore, links starting with `XXXX://` or `//` are ignore. In this example `not-copy.rar` is not copied.
+Similarly, `report.css` and `diagram.png` should be in the same directory as the Markdown file. In this example, `report.html` has its own internal relative links to these files. `report.html` is not changed in any way. The relative links to the copied files work from the copied location.
+
+The copy target is a relative link. Therefore, links starting with `XXXX://` or `//` are ignored. In this example `not-copy.rar` is not copied.
 
 ## Options
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -240,6 +240,57 @@ describe('gatsby-remark-copy-relative-linked-files', () => {
         expect(FsExtra.copy).not.toHaveBeenCalled()
       })
     })
+
+    describe('manifest', () => {
+      test('One file', async () => {
+        const path = 'sample.thumb.jpg'
+        const markdownAST = remark.parse(`\`\`\`copyfiles\n${path}\n\`\`\``)
+
+        await Plugin({
+          files: getFiles(path),
+          markdownAST,
+          markdownNode,
+          getNode
+        })
+
+        expect(FsExtra.copy).toHaveBeenCalled()
+        expect(markdownAST.children.findIndex(
+          node => node.type === "code" && node.lang === "copyfiles"
+        )).toEqual(-1);
+      })
+
+      test('Two files', async () => {
+        const path1 = 'report.css'
+        const path2 = 'diagram.png'
+        const markdownAST = remark.parse(`\`\`\`copyfiles\n${path1}\n${path2}\n\`\`\``)
+
+        await Plugin({
+          files: getFiles(path1).concat(getFiles(path2)),
+          markdownAST,
+          markdownNode,
+          getNode
+        })
+
+        expect(FsExtra.copy).toHaveBeenNthCalledWith(1, path1, expect.anything(), expect.anything())
+        expect(FsExtra.copy).toHaveBeenNthCalledWith(2, path2, expect.anything(), expect.anything())
+      })
+
+      test('Tolerates whitespace', async () => {
+        const path1 = 'report.css'
+        const path2 = 'diagram.png'
+        const markdownAST = remark.parse(`\`\`\`copyfiles\n   ${path1}\n${path2}   \n\`\`\``)
+
+        await Plugin({
+          files: getFiles(path1).concat(getFiles(path2)),
+          markdownAST,
+          markdownNode,
+          getNode
+        })
+
+        expect(FsExtra.copy).toHaveBeenNthCalledWith(1, path1, expect.anything(), expect.anything())
+        expect(FsExtra.copy).toHaveBeenNthCalledWith(2, path2, expect.anything(), expect.anything())
+      })
+    })
   })
 
   // For private API


### PR DESCRIPTION
This adds a feature where a Remark document can request additional files to be copied without linking to them directly. This is useful when a Remark document links to a resource that depends on other resources, such as to an HTML file. To do this, the document declares a "copyfiles" code fence:

```markdown
    See [this generated report](report.html) for more information.

    ```copyfiles
    report.css
    diagram.png
    ```
```

This is option 3 discussed in feature request issue #4.

Tested with:

```bash
gatsby new test-md-blog https://github.com/gatsbyjs/gatsby-starter-blog
cd test-md-blog
npm install --save dansanderson/npm-gatsby-remark-copy-relative-linked-files
```

Edited gatsby-config.js to replace gatsby-remark-copy-linked-files with gatsby-remark-copy-relative-linked-files *and reordered the plugins* so this one comes before prismjs. Then set up an example similar to the above in the `hello-world` blog entry, `gatsby build`, `gatsby serve`. Confirmed that the example works.

Feel free to reject if you don't like this design. This fork works for me. :) Thanks!