### PR TITLE
Copy video and audio from HTML and JSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "fs-extra": "^7.0.1",
+    "htmlparser2": "^4.1.0",
     "unist-util-visit": "^1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
First draft for also copying video and audio files (inspired by the [similar technique in `gatsby-remark-copy-linked-files`](https://github.com/gatsbyjs/gatsby/blob/6270c3d09ba5abfcd73197a3632bdbc737e96768/packages/gatsby-remark-copy-linked-files/src/index.js#L219-L301))

Uses the performant and small [`htmlparser2`](https://github.com/fb55/htmlparser2) library.

Closes #7