### PR TITLE
fix: esm error

### DIFF
--- a/examples/gatsby-node.js
+++ b/examples/gatsby-node.js
@@ -22,7 +22,7 @@ exports.createPages = ({ actions, graphql }) => {
   const { createPage } = actions
   return graphql(`
     {
-      allMarkdownRemark(sort: { fields: [frontmatter___date], order: DESC }) {
+      allMarkdownRemark(sort: { frontmatter: { date: DESC } }) {
         edges {
           node {
             html

--- a/examples/package.json
+++ b/examples/package.json
@@ -25,17 +25,16 @@
     "test": "echo \"Write tests! -> https://gatsby.dev/unit-testing\" && exit 1"
   },
   "dependencies": {
-    "gatsby": "^4.4.0",
-    "gatsby-plugin-react-helmet": "^5.4.0",
+    "gatsby": "^5.14.0",
+    "gatsby-plugin-react-helmet": "^6.14.0",
     "gatsby-remark-copy-relative-linked-files": "latest",
-    "gatsby-source-filesystem": "^4.4.0",
-    "gatsby-transformer-remark": "^5.4.0",
-    "prop-types": "^15.8.0",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "gatsby-source-filesystem": "^5.14.0",
+    "gatsby-transformer-remark": "^6.14.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0"
   },
   "devDependencies": {
-    "prettier": "^2.5.1"
+    "prettier": "^3.3.3"
   }
 }

--- a/examples/src/components/header.js
+++ b/examples/src/components/header.js
@@ -1,6 +1,5 @@
 import React from "react"
-import PropTypes from "prop-types"
-import Link from "gatsby-link"
+import { Link } from "gatsby-link"
 
 const Header = ({ siteTitle, siteSubTitle }) => (
   <header className="header">
@@ -10,10 +9,5 @@ const Header = ({ siteTitle, siteSubTitle }) => (
     <h2 className="subtitle">{siteSubTitle}</h2>
   </header>
 )
-
-Header.propTypes = {
-  siteTitle: PropTypes.string,
-  siteSubTitle: PropTypes.string,
-}
 
 export default Header

--- a/examples/src/components/layout.js
+++ b/examples/src/components/layout.js
@@ -6,7 +6,6 @@
  */
 
 import * as React from "react"
-import PropTypes from "prop-types"
 import { useStaticQuery, graphql } from "gatsby"
 
 import Header from "./header"
@@ -39,10 +38,6 @@ const Layout = ({ children }) => {
       </div>
     </>
   )
-}
-
-Layout.propTypes = {
-  children: PropTypes.node.isRequired,
 }
 
 export default Layout

--- a/examples/src/pages/404.js
+++ b/examples/src/pages/404.js
@@ -1,5 +1,4 @@
 import React from "react"
-import PropTypes from "prop-types"
 import { graphql } from "gatsby"
 import Header from "../components/header.js"
 
@@ -17,10 +16,6 @@ const NotFoundPage = ({ data }) => (
     </div>
   </div>
 )
-
-NotFoundPage.propTypes = {
-  data: PropTypes.object,
-}
 
 export default NotFoundPage
 

--- a/examples/src/templates/post.js
+++ b/examples/src/templates/post.js
@@ -1,5 +1,4 @@
 import React from "react"
-import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { graphql } from "gatsby"
 import Header from "../components/header.js"
@@ -30,11 +29,6 @@ const Template = ({ data, pageContext }) => {
       </div>
     </div>
   )
-}
-
-Template.propTypes = {
-  data: PropTypes.object,
-  pageContext: PropTypes.object,
 }
 
 export const pageQuery = graphql`

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "fs-extra": "^11.2.0",
     "htmlparser2": "^9.1.0",
-    "unist-util-visit": "^5.0.0",
+    "unist-util-visit": "^2.0.3",
     "upath": "^2.0.1"
   },
   "devDependencies": {

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,4 @@
-import { visit } from 'unist-util-visit'
+import visit from 'unist-util-visit'
 import fsExtra from 'fs-extra'
 import path from 'upath'
 import { Parser } from 'htmlparser2'


### PR DESCRIPTION
- Reverted unist-util-visit to the version before ESM, referring to gatsby-remark-copy-linked-files.
- Update the dependencies of the examples to the latest version
- Checked the operation of the npm packed example.

```
require() of ES Module .../npm-gatsby-remark-copy-relative-linked-files/examples/node_modules/
unist-util-visit/index.js from .../npm-gatsby-remark-copy-relative-linked-files/examples/node_
modules/gatsby-remark-copy-relative-linked-files/dist/plugin.js not supported.
Instead change the require of index.js in .../npm-gatsby-remark-copy-relative-linked-files/exa
mples/node_modules/gatsby-remark-copy-relative-linked-files/dist/plugin.js to a dynamic import() which is available in all
CommonJS modules. (plugins)
```